### PR TITLE
Corrige consulta de resolución en reportes

### DIFF
--- a/app/scripts/controllers/vinculacionespecial/resolucion_reportes.js
+++ b/app/scripts/controllers/vinculacionespecial/resolucion_reportes.js
@@ -31,7 +31,9 @@ angular.module('contractualClienteApp')
       if (self.facultad && self.numeroResolucion && self.vigencia) {
         administrativaRequest.get("resolucion", $.param({
           query: "IdDependencia:" + self.facultad + ",Vigencia:" + self.vigencia + ",NumeroResolucion:" + self.numeroResolucion,
-          limit: 1
+          limit: 1,
+          sortby: "id_resolucion",
+          order: "desc"
         }, true)).then(function (resolucion) {
           if (resolucion.data !== null ){
             if (resolucion.data[0].IdTipoResolucion.Id === 1){


### PR DESCRIPTION
Se corrige la consulta para que tome el ID de la última resolución creada (con el mismo número, facultad y vigencia), ya que al tener varias anuladas estaba tomando la primera y por eso no permitía mostrar el reporte.